### PR TITLE
Make the basic operator work with v0.9.0 release of OperatorSDK

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.6.0
+FROM quay.io/operator-framework/ansible-operator:v0.9.0
 USER root
 RUN pip install etcd3
 RUN pip install boto3

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,13 +19,15 @@ spec:
             - /usr/local/bin/ao-logs
             - /tmp/ansible-operator/runner
             - stdout
-          image: quay.io/alaypatel07/etcd-ha-operator:v0.6.0
+#          TODO: change the image name
+          image: quay.io/alaypatel07/etcd-ha-operator:v0.9.0
           volumeMounts:
             - mountPath: /tmp/ansible-operator/runner
               name: runner
               readOnly: true
         - name: etcd-ha-operator
-          image: quay.io/alaypatel07/etcd-ha-operator:v0.6.0
+#          TODO: change the image name
+          image: quay.io/alaypatel07/etcd-ha-operator:v0.9.0
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -30,8 +30,9 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployment
+  - deployments
   - statefulsets
+  - replicasets
   verbs:
   - "*"
 

--- a/roles/reconcile/tasks/create_certs.yaml
+++ b/roles/reconcile/tasks/create_certs.yaml
@@ -6,7 +6,7 @@
   set_fact:
 #    operator_secret: "{{ lookup('k8s', api_version='v1', kind='Secret', namespace=etcd_namespace,
 #                                  resource_name=_tls.static.operator_secret) }}"
-    tls_directory: "/tmp/etcdtls/{{etcd_cluster_name}}"
+    tls_directory: "/tmp/etcdtls/{{etcd_cluster_name}}/{{tls_secret_name}}"
     ca_cert: "{{ operator_secret['data']['etcd-client-ca.crt'] | b64decode}}"
     client_cert: "{{ operator_secret['data']['etcd-client.crt'] | b64decode}}"
     client_key: "{{ operator_secret['data']['etcd-client.key'] | b64decode}}"

--- a/roles/reconcile/tasks/reconcile_pods.yaml
+++ b/roles/reconcile/tasks/reconcile_pods.yaml
@@ -28,6 +28,9 @@
   - name: set cluster status when new
     vars:
       etcd_status: "Creating"
+      peer_tls_secret: "{{ peer_tls_secret }}"
+      server_tls_secret: "{{ server_tls_secret }}"
+      operator_tls_secret: "{{ operator_tls_secret }}"
     k8s_status:
       api_version: etcd.database.coreos.com/v1beta3
       kind: EtcdCluster
@@ -39,9 +42,9 @@
 
 - name: set TLS status variables when present
   set_fact:
-    peer_tls_secret: "{{ etcd_stateful_set[0].get('status', {}).get('peerTLSSecret', '') }}"
-    server_tls_secret: "{{ etcd_stateful_set[0].get('status', {}).get('serverTLSSecret', '') }}"
-    operator_tls_secret: "{{ etcd_stateful_set[0].get('status', {}).get('operatorTLSSecret', '') }}"
+    peer_tls_secret: "{{ _etcd_database_coreos_com_etcdcluster.get('status', {}).get('peerTLSSecret', '') }}"
+    server_tls_secret: "{{ _etcd_database_coreos_com_etcdcluster.get('status', {}).get('serverTLSSecret', '') }}"
+    operator_tls_secret: "{{ _etcd_database_coreos_com_etcdcluster.get('status', {}).get('operatorTLSSecret', '') }}"
   when: etcd_cluster_phase == "existing" and etcd_secure_client == "present" and etcd_secure_peer == "present"
 
 - name: set TLS status variables when absent
@@ -54,7 +57,7 @@
 - name: set cluster member names
   set_fact:
     etcd_cluster_member_names: "{{ etcd_cluster_member_names + [etcd_cluster_name + '-' + item|string] }}"
-  with_sequence: start={{0}} end={{size - 1}}
+  with_sequence: start={{0}} end={{size|int - 1}}
   when: etcd_cluster_phase == "existing"
 
 - name: check if TLS rotation
@@ -82,14 +85,24 @@
   when: (etcd_cluster_phase == "existing" and etcd_secure_client == "present")
   ignore_errors: yes
 
+- name: update tls variables
+  set_fact:
+    peer_tls_secret: "{{ _tls.static.member.peer_secret }}"
+    server_tls_secret: "{{ _tls.static.member.server_secret }}"
+    operator_tls_secret: "{{ _tls.static.operator_secret }}"
+  when: etcd_cluster_phase == "existing" and etcd_secure_client == "present" and etcd_secure_peer == "present"
+
 - block:
 
   - name: Set status and exit when cluster is unavailable
     vars:
       etcd_status: "Unavailable"
       etcd_status_reason: "Etcd is trying to establish quorum"
+      peer_tls_secret: "{{ peer_tls_secret }}"
+      server_tls_secret: "{{ server_tls_secret }}"
+      operator_tls_secret: "{{ operator_tls_secret }}"
     k8s_status:
-      api_version: etcd.database.coreos.com/v1beta2
+      api_version: etcd.database.coreos.com/v1beta3
       kind: EtcdCluster
       name: "{{ etcd_cluster_name }}"
       namespace: "{{ etcd_namespace }}"
@@ -103,6 +116,9 @@
 - name: Set status when cluster is available
   vars:
     etcd_status: Available
+    peer_tls_secret: "{{ peer_tls_secret }}"
+    server_tls_secret: "{{ server_tls_secret }}"
+    operator_tls_secret: "{{ operator_tls_secret }}"
   k8s_status:
     api_version: etcd.database.coreos.com/v1beta3
     kind: EtcdCluster
@@ -122,6 +138,9 @@
   - name: Set status when Scaling
     vars:
       etcd_status: Scaling
+      peer_tls_secret: "{{ peer_tls_secret }}"
+      server_tls_secret: "{{ server_tls_secret }}"
+      operator_tls_secret: "{{ operator_tls_secret }}"
     k8s_status:
       api_version: etcd.database.coreos.com/v1beta3
       kind: EtcdCluster

--- a/roles/reconcile/tasks/rotate_tls.yaml
+++ b/roles/reconcile/tasks/rotate_tls.yaml
@@ -1,47 +1,49 @@
-- name: set cluster status before rotating TLS
-  vars:
-    etcd_status: "Rotating TLS"
-    peer_tls_secret: etcd_stateful_set[0].status.peerTLSSecret
-    server_tls_secret: etcd_stateful_set[0].status.serverTLSSecret
-    operator_tls_secret: etcd_stateful_set[0].status.operatorTLSSecret
-  k8s_status:
-    api_version: etcd.database.coreos.com/v1beta3
-    kind: EtcdCluster
-    name: "{{ etcd_cluster_name }}"
-    namespace: "{{ etcd_namespace }}"
-    status: "{{ lookup('template', 'status.yaml') | from_yaml }}"
+- block:
+  - name: set cluster status before rotating TLS
+    vars:
+      etcd_status: "Rotating TLS"
+      peer_tls_secret: "{{ _etcd_database_coreos_com_etcdcluster.status.peerTLSSecret }}"
+      server_tls_secret: "{{ _etcd_database_coreos_com_etcdcluster.status.serverTLSSecret }}"
+      operator_tls_secret: "{{ _etcd_database_coreos_com_etcdcluster.status.operatorTLSSecret }}"
+    k8s_status:
+      api_version: etcd.database.coreos.com/v1beta3
+      kind: EtcdCluster
+      name: "{{ etcd_cluster_name }}"
+      namespace: "{{ etcd_namespace }}"
+      status: "{{ lookup('template', 'status.yaml') | from_yaml }}"
 
-- name: patch the statefulset with new TLS and wait for pods to get restarted
-  vars:
-    size: "{{ etcd_stateful_set[0].spec.replicas }}"
-    peer_tls_secret: etcd_stateful_set[0].status.peerTLSSecret
-    server_tls_secret: etcd_stateful_set[0].status.serverTLSSecret
-    operator_tls_secret: etcd_stateful_set[0].status.operatorTLSSecret
-  k8s:
-    state: "present"
-    definition: "{{ lookup('template', 'ss.yaml') | from_yaml }}"
-  when: peer_tls_secret != _tls.static.member.peer_secret or server_tls != _tls.static.member.server_secret or operator_tls_secret != _tls.static.operator_secret
+  - name: patch the statefulset with new TLS and wait for pods to get restarted
+    vars:
+      size: "{{ etcd_stateful_set[0].spec.replicas }}"
+      peer_tls_secret: "{{ _tls.static.member.peer_secret }}"
+      server_tls_secret: "{{ _tls.static.member.server_secret }}"
+      operator_tls_secret: "{{ _tls.static.operator_secret }}"
+    k8s:
+      state: "present"
+      definition: "{{ lookup('template', 'ss.yaml') | from_yaml }}"
 
-- pause:
-    seconds: 1
+  - pause:
+      seconds: 1
 
-- name: make sure all the pods are running with new TLS
-  k8s_facts:
-    kind: StatefulSet
-    api_version: apps/v1
-    namespace: "{{ etcd_namespace }}"
-    name: "{{ etcd_cluster_name }}"
-  register: sts
-  until: sts.get("resources", []) and sts.resources[0].get("status", {}).get("readyReplicas", 0) == size
-  retries: 30
-  delay: 10
+  - name: make sure all the pods are running with new TLS
+    k8s_facts:
+      kind: StatefulSet
+      api_version: apps/v1
+      namespace: "{{ etcd_namespace }}"
+      name: "{{ etcd_cluster_name }}"
+    register: sts
+    until: sts.get("resources", []) and sts.resources[0].get("status", {}).get("readyReplicas", 0) == size
+    retries: 30
+    delay: 10
+
+  when: peer_tls_secret != _tls.static.member.peer_secret or server_tls_secret != _tls.static.member.server_secret or operator_tls_secret != _tls.static.operator_secret
 
 - name: set cluster status with new TLS Secrets
   vars:
-    etcd_status: "Rotating TLS"
-    peerTLSSecret: _tls.static.member.peer_secret
-    serverTLSSecret: _tls.static.member.server_secret
-    operatorTLSSecret: _tls.static.operator_secret
+    etcd_status: "Available"
+    peer_tls_secret: "{{ _tls.static.member.peer_secret }}"
+    server_tls_secret: "{{ _tls.static.member.server_secret }}"
+    operator_tls_secret: "{{ _tls.static.operator_secret }}"
   k8s_status:
     api_version: etcd.database.coreos.com/v1beta3
     kind: EtcdCluster

--- a/roles/tls_certs/tasks/create_secrets.yaml
+++ b/roles/tls_certs/tasks/create_secrets.yaml
@@ -53,8 +53,8 @@
         name: "{{ etcd_server_secret_name }}"
         namespace: "{{ etcd_namespace }}"
         labels:
-        app: "{{ etcd_app_label }}"
-        etcd_cluster: "{{ etcd_cluster_name }}"
+          app: "{{ etcd_app_label }}"
+          etcd_cluster: "{{ etcd_cluster_name }}"
       data:
         "server.key": "{{ etcd_server_key_value }}"
         "server.crt": "{{ etcd_server_crt_value }}"


### PR DESCRIPTION
This PR builds the operator using the latest build of operator-sdk. A user can deploy their own image using:

`operator-sdk build docker.io/username/etcd-ha-operator:test && docker push git@github.com:alaypatel07/etcd-ha-operator.git` and changing the image name in `deploy/operator.yaml`

/cc @hexfusion @retroflexer 