### PR TITLE
Modified clusterrole that is bound to Operator's service account to support update finalizers

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -38,6 +38,7 @@ rules:
 - apiGroups: ["apps"]
   resources:
   - deployments/finalizers
+  - services/finalizers
   verbs:
   - update
 ---

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -35,7 +35,11 @@ rules:
   - replicasets
   verbs:
   - "*"
-
+- apiGroups: ["apps"]
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
 ---
 
 kind: ClusterRoleBinding


### PR DESCRIPTION
The operator fails to come up with the below error. 
[FYR](https://github.com/operator-framework/operator-sdk/issues/1736)
```

oc logs etcd-ha-operator-664c9f84fd-5bwd7  -c etcd-ha-operator
{"level":"info","ts":1585597181.4909885,"logger":"cmd","msg":"Go Version: go1.12.7"}
{"level":"info","ts":1585597181.491039,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1585597181.4910443,"logger":"cmd","msg":"Version of operator-sdk: v0.9.0"}
{"level":"info","ts":1585597181.4910612,"logger":"cmd","msg":"Watching namespace.","Namespace":"default"}
{"level":"info","ts":1585597181.7042906,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1585597181.9254153,"logger":"leader","msg":"Found existing lock with my name. I was likely restarted."}
{"level":"info","ts":1585597181.9254937,"logger":"leader","msg":"Continuing as the leader."}
{"level":"error","ts":1585597182.165923,"logger":"cmd","msg":"Exposing metrics port failed.","Namespace":"default","error":"failed to create or get service for metrics: services \"etcd-ha-operator-metrics\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\ngithub.com/operator-framework/operator-sdk/pkg/ansible.Run\n\tsrc/github.com/operator-framework/operator-sdk/pkg/ansible/run.go:103\ngithub.com/operator-framework/operator-sdk/cmd/operator-sdk/run.newRunAnsibleCmd.func1\n\tsrc/github.com/operator-framework/operator-sdk/cmd/operator-sdk/run/ansible.go:38\ngithub.com/spf13/cobra.(*Command).execute\n\tpkg/mod/github.com/spf13/cobra@v0.0.3/command.go:762\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tpkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852\ngithub.com/spf13/cobra.(*Command).Execute\n\tpkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800\nmain.main\n\tsrc/github.com/operator-framework/operator-sdk/cmd/operator-sdk/main.go:85\nruntime.main\n\t/home/travis/.gimme/versions/go1.12.7.linux.amd64/src/runtime/proc.go:200"}
Error: failed to create or get service for metrics: services "etcd-ha-operator-metrics" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```

This PR modifies the clusterrole to include update permissions for the resource deployment/finalizers. 